### PR TITLE
fix bug when the number of segments is integer(line-chunk)

### DIFF
--- a/packages/turf-line-chunk/index.js
+++ b/packages/turf-line-chunk/index.js
@@ -64,7 +64,12 @@ function sliceLineSegments(line, segmentLength, units, callback) {
     // If the line is shorter than the segment length then the orginal line is returned.
     if (lineLength <= segmentLength) return callback(line);
 
-    var numberOfSegments = Math.floor(lineLength / segmentLength) + 1;
+    var numberOfSegments = lineLength / segmentLength;
+    // If numberOfSegments is integer, no need to plus 1
+    if(!Number.isInteger(numberOfSegments)){
+        numberOfSegments = Math.floor(numberOfSegments) + 1;
+    }
+    
     for (var i = 0; i < numberOfSegments; i++) {
         var outline = lineSliceAlong(line, segmentLength * i, segmentLength * (i + 1), {units: units});
         callback(outline, i);


### PR DESCRIPTION
if numberOfSegments is an integer,  like line length is 100, and segmentLength is 10, it's just 10 segments, no need to plus 1 to 11, otherwise will throw an exception later.
